### PR TITLE
feat: changes in taxes_and_totals.py for enabling multiple margin pricing rules

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -375,6 +375,41 @@ class TestPricingRule(IntegrationTestCase):
 		self.assertEqual(item.discount_amount, 110)
 		self.assertEqual(item.rate, 990)
 
+	def test_pricing_rule_with_multiple_margins(self):
+		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule")
+		make_pricing_rule(
+			selling=1,
+			margin_type="Percentage",
+			margin_rate_or_amount=10,
+			rate_or_discount="Discount Amount",
+			discount_amount=0,
+		)
+		make_pricing_rule(
+			selling=1,
+			margin_type="Percentage",
+			margin_rate_or_amount=5,
+			rate_or_discount="Discount Amount",
+			discount_amount=0,
+		)
+		make_pricing_rule(
+			selling=1,
+			margin_type="Amount",
+			margin_rate_or_amount=100,
+			rate_or_discount="Discount Amount",
+			discount_amount=0,
+		)
+
+		si = create_sales_invoice(do_not_save=True)
+		si.items[0].price_list_rate = 1000
+		si.payment_schedule = []
+		si.insert(ignore_permissions=True)
+
+		item = si.items[0]
+		self.assertEqual(item.margin_type, "Amount")
+		self.assertEqual(item.margin_rate_or_amount, 250)
+		self.assertEqual(item.rate_with_margin, 1250)
+		self.assertEqual(item.rate, 1250)
+
 	def test_pricing_rule_for_product_discount_on_same_item(self):
 		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule")
 		test_record = {

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -382,6 +382,7 @@ class TestPricingRule(IntegrationTestCase):
 			margin_type="Percentage",
 			margin_rate_or_amount=10,
 			rate_or_discount="Discount Amount",
+			apply_multiple_pricing_rules=1,
 			discount_amount=0,
 		)
 		make_pricing_rule(
@@ -389,6 +390,7 @@ class TestPricingRule(IntegrationTestCase):
 			margin_type="Percentage",
 			margin_rate_or_amount=5,
 			rate_or_discount="Discount Amount",
+			apply_multiple_pricing_rules=1,
 			discount_amount=0,
 		)
 		make_pricing_rule(
@@ -396,6 +398,7 @@ class TestPricingRule(IntegrationTestCase):
 			margin_type="Amount",
 			margin_rate_or_amount=100,
 			rate_or_discount="Discount Amount",
+			apply_multiple_pricing_rules=1,
 			discount_amount=0,
 		)
 

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -390,16 +390,16 @@ class TestPricingRule(IntegrationTestCase):
 			margin_type="Percentage",
 			margin_rate_or_amount=5,
 			rate_or_discount="Discount Amount",
-			apply_multiple_pricing_rules=1,
 			discount_amount=0,
+			apply_multiple_pricing_rules=1,
 		)
 		make_pricing_rule(
 			selling=1,
 			margin_type="Amount",
 			margin_rate_or_amount=100,
 			rate_or_discount="Discount Amount",
-			apply_multiple_pricing_rules=1,
 			discount_amount=0,
+			apply_multiple_pricing_rules=1,
 		)
 
 		si = create_sales_invoice(do_not_save=True)

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -962,28 +962,49 @@ class calculate_taxes_and_totals:
 		if item.price_list_rate:
 			if item.pricing_rules and not self.doc.ignore_pricing_rule:
 				has_margin = False
-				item.margin_rate_or_amount = 0
 
-				for d in get_applied_pricing_rules(item.pricing_rules):
-					pricing_rule = frappe.get_cached_doc("Pricing Rule", d)
+				applied_pricing_rules = get_applied_pricing_rules(item.pricing_rules)
 
-					if (
-						pricing_rule.margin_rate_or_amount
-						and pricing_rule.currency == self.doc.currency
-					):
-						if pricing_rule.margin_type == "Percentage":
-							item.margin_type = "Amount"
-							item.margin_rate_or_amount += item.price_list_rate * (
-								pricing_rule.margin_rate_or_amount / 100
+				# If only one pricing rule is applied
+				if len(applied_pricing_rules) == 1:
+
+					for d in applied_pricing_rules:
+						pricing_rule = frappe.get_cached_doc("Pricing Rule", d)
+
+						if pricing_rule.margin_rate_or_amount and (
+							(
+								pricing_rule.currency == self.doc.currency
+								and pricing_rule.margin_type in ["Amount", "Percentage"]
 							)
+							or pricing_rule.margin_type == "Percentage"
+						):
+							item.margin_type = pricing_rule.margin_type
+							item.margin_rate_or_amount = pricing_rule.margin_rate_or_amount
 							has_margin = True
 
-						elif pricing_rule.margin_type == "Amount":
-							item.margin_type = "Amount"
-							item.margin_rate_or_amount += (
-								pricing_rule.margin_rate_or_amount
-							)
-							has_margin = True
+				# If multiple pricing rules are applied
+				if len(applied_pricing_rules) > 1:
+					
+					item.margin_rate_or_amount = 0
+					for d in applied_pricing_rules:
+						pricing_rule = frappe.get_cached_doc("Pricing Rule", d)
+
+						if (
+							pricing_rule.margin_rate_or_amount
+						):
+							if pricing_rule.margin_type == "Percentage":
+								item.margin_type = "Amount"
+								item.margin_rate_or_amount += item.price_list_rate * (
+									pricing_rule.margin_rate_or_amount / 100
+								)
+								has_margin = True
+
+							elif pricing_rule.margin_type == "Amount" and pricing_rule.currency == self.doc.currency:
+								item.margin_type = "Amount"
+								item.margin_rate_or_amount += (
+									pricing_rule.margin_rate_or_amount
+								)
+								has_margin = True
 
 				if not has_margin:
 					item.margin_type = None

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -967,7 +967,6 @@ class calculate_taxes_and_totals:
 
 				# If only one pricing rule is applied
 				if len(applied_pricing_rules) == 1:
-
 					for d in applied_pricing_rules:
 						pricing_rule = frappe.get_cached_doc("Pricing Rule", d)
 
@@ -984,14 +983,11 @@ class calculate_taxes_and_totals:
 
 				# If multiple pricing rules are applied
 				if len(applied_pricing_rules) > 1:
-					
 					item.margin_rate_or_amount = 0
 					for d in applied_pricing_rules:
 						pricing_rule = frappe.get_cached_doc("Pricing Rule", d)
 
-						if (
-							pricing_rule.margin_rate_or_amount
-						):
+						if pricing_rule.margin_rate_or_amount:
 							if pricing_rule.margin_type == "Percentage":
 								item.margin_type = "Amount"
 								item.margin_rate_or_amount += item.price_list_rate * (
@@ -999,11 +995,12 @@ class calculate_taxes_and_totals:
 								)
 								has_margin = True
 
-							elif pricing_rule.margin_type == "Amount" and pricing_rule.currency == self.doc.currency:
+							elif (
+								pricing_rule.margin_type == "Amount"
+								and pricing_rule.currency == self.doc.currency
+							):
 								item.margin_type = "Amount"
-								item.margin_rate_or_amount += (
-									pricing_rule.margin_rate_or_amount
-								)
+								item.margin_rate_or_amount += pricing_rule.margin_rate_or_amount
 								has_margin = True
 
 				if not has_margin:


### PR DESCRIPTION
Hello everyone :),

we have created an issue with ERPNext, where we describe a problem with the calculation of multiple pricing rules in ERPNext.

https://github.com/frappe/erpnext/issues/43048

To see and understand the problem in its details, please look at the issue and take a look at the video i made for that. :)!

Therefore with this pull request we have already implemented a solution for that problem, which keeps the old functionality but also calculates not the right amounts with multiple pricing rules.

We have also made a video, where we show how our solution works. :) So please watch the video if you want to know more.

Thank you guys for considering this pull request and if you need anything, you can let me know.

Please backport to v15 and v14 if possible!

Best Regards
Dietmar


https://github.com/user-attachments/assets/38aa541e-e809-4c44-97e5-b6edd608006c

